### PR TITLE
Merge to live - add "rest_product" as global metadata

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -50,6 +50,8 @@
     "overwrite": [],
     "externalReference": [],
     "globalMetadata": {
+      "rest_product": "Operations Manager",
+      "titleSuffix": "Operations Manager REST API",
       "breadcrumb_path": "/rest/breadcrumb/toc.json",
       "extendBreadcrumb": true
     },


### PR DESCRIPTION
To make reference tab title include "Dynamics 365" and more SEO friendly.